### PR TITLE
cmdTripleDict was not filled in the beginning of addN

### DIFF
--- a/rdflib_sqlalchemy/SQLAlchemy.py
+++ b/rdflib_sqlalchemy/SQLAlchemy.py
@@ -685,7 +685,7 @@ class SQLAlchemy(Store, SQLGenerator):
                     context,
                     isinstance(context, QuotedGraph))
 
-            cmdTriple = cmdTripleDict.get(buildCommandType, {})
+            cmdTriple = cmdTripleDict.setdefault(buildCommandType, {})
             cmdTriple.setdefault('cmd', cmd)
             cmdTriple.setdefault('params', []).append(params)
 


### PR DESCRIPTION
When testing rdflib-sqlalchemy to write to differents stores, we used something simplar but similar to sp2b.py and we noticed that the item where not written in the store. 
It seems to be a problem in SQLAlchmy.addN() method.

```python
    gm = rdflib.Graph()
    gm.add((rdflib.BNode(), RDF.type, FOAF.Person))
    with BZ2File(".../rdflib-benchmark/sp2b/500.n3.bz2") as f:
        gm.parse(f, format='n3')
    g = rdflib.Graph(store="SQLAlchemy")
    g.open("sqlite:///test-triples.db", create=True)
    g += gm
    g.commit()
    print "Graph length in memory : %d" % len(gm)
    print "Graph length in SQLite : %d" % len(g)
```
