### PR TITLE
Python 3 compatibility; flake8 compatibility; numerous small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ python:
     - 3.4
     - 3.5
 install:
-    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '2' ]]; then pip install -r requirements-py2.txt --use-mirrors; fi
-    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '3' ]]; then pip install -r requirements-py3.txt --use-mirrors; fi
+    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '2' ]]; then pip install -r requirements-py2.txt; fi
+    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '3' ]]; then pip install -r requirements-py3.txt; fi
     - python setup.py install
 before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS test;' -U postgres; psql -c 'create database test;' -U postgres; export DBURI='postgresql+psycopg2://postgres@localhost/test'; fi"

--- a/rdflib_sqlalchemy/__init__.py
+++ b/rdflib_sqlalchemy/__init__.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 """SQLAlchemy Store plugin for RDFLib."""
 import logging
+
+
 __author__ = "Graham Higgins"
 __version__ = "0.3"
 
 
 class NullHandler(logging.Handler):
-    r"""
+    """
     Null handler.
 
     c.f.
@@ -41,7 +43,7 @@ def registerplugins():
     from rdflib import plugin
 
     try:
-        x = plugin.get('SQLAlchemy', Store)
+        x = plugin.get("SQLAlchemy", Store)
         del x
         return  # plugins already registered
     except:
@@ -50,5 +52,8 @@ def registerplugins():
     # Register the plugins ...
 
     plugin.register(
-        'SQLAlchemy', Store,
-        'rdflib_sqlalchemy.SQLAlchemy', 'SQLAlchemy')
+        "SQLAlchemy",
+        Store,
+        "rdflib_sqlalchemy.store",
+        "SQLAlchemy",
+    )

--- a/rdflib_sqlalchemy/termutils.py
+++ b/rdflib_sqlalchemy/termutils.py
@@ -4,67 +4,68 @@ from rdflib import Graph
 from rdflib import Literal
 from rdflib import URIRef
 from rdflib import Variable
-from rdflib.term import Statement
 from rdflib.graph import QuotedGraph
 from rdflib.py3compat import format_doctest_out
+from rdflib.term import Statement
 
-__all__ = ['SUBJECT', 'PREDICATE', 'OBJECT', 'CONTEXT', 'TERM_COMBINATIONS',
-           'REVERSE_TERM_COMBINATIONS', 'TERM_INSTANTIATION_DICT',
-           'GRAPH_TERM_DICT', 'normalizeGraph', 'term2Letter',
-           'constructGraph', 'triplePattern2termCombinations',
-           'type2TermCombination', 'statement2TermCombination',
-           'escape_quotes']
+
+__all__ = ["SUBJECT", "PREDICATE", "OBJECT", "CONTEXT", "TERM_COMBINATIONS",
+           "REVERSE_TERM_COMBINATIONS", "TERM_INSTANTIATION_DICT",
+           "GRAPH_TERM_DICT", "normalizeGraph", "term2Letter",
+           "constructGraph", "triplePattern2termCombinations",
+           "type2TermCombination", "statement2TermCombination",
+           "escape_quotes"]
 
 SUBJECT = 0
 PREDICATE = 1
 OBJECT = 2
 CONTEXT = 3
 TERM_COMBINATIONS = dict([(term, index) for index, term, in enumerate([
-     'UUUU', 'UUUB', 'UUUF', 'UUVU', 'UUVB', 'UUVF', 'UUBU', 'UUBB', 'UUBF',
-     'UULU', 'UULB', 'UULF', 'UUFU', 'UUFB', 'UUFF',
+     "UUUU", "UUUB", "UUUF", "UUVU", "UUVB", "UUVF", "UUBU", "UUBB", "UUBF",
+     "UULU", "UULB", "UULF", "UUFU", "UUFB", "UUFF",
      #
-     'UVUU', 'UVUB', 'UVUF', 'UVVU', 'UVVB', 'UVVF', 'UVBU', 'UVBB', 'UVBF',
-     'UVLU', 'UVLB', 'UVLF', 'UVFU', 'UVFB', 'UVFF',
+     "UVUU", "UVUB", "UVUF", "UVVU", "UVVB", "UVVF", "UVBU", "UVBB", "UVBF",
+     "UVLU", "UVLB", "UVLF", "UVFU", "UVFB", "UVFF",
      #
-     'VUUU', 'VUUB', 'VUUF', 'VUVU', 'VUVB', 'VUVF', 'VUBU', 'VUBB', 'VUBF',
-     'VULU', 'VULB', 'VULF', 'VUFU', 'VUFB', 'VUFF',
+     "VUUU", "VUUB", "VUUF", "VUVU", "VUVB", "VUVF", "VUBU", "VUBB", "VUBF",
+     "VULU", "VULB", "VULF", "VUFU", "VUFB", "VUFF",
      #
-     'VVUU', 'VVUB', 'VVUF', 'VVVU', 'VVVB', 'VVVF', 'VVBU', 'VVBB', 'VVBF',
-     'VVLU', 'VVLB', 'VVLF', 'VVFU', 'VVFB', 'VVFF',
+     "VVUU", "VVUB", "VVUF", "VVVU", "VVVB", "VVVF", "VVBU", "VVBB", "VVBF",
+     "VVLU", "VVLB", "VVLF", "VVFU", "VVFB", "VVFF",
      #
-     'BUUU', 'BUUB', 'BUUF', 'BUVU', 'BUVB', 'BUVF', 'BUBU', 'BUBB', 'BUBF',
-     'BULU', 'BULB', 'BULF', 'BUFU', 'BUFB', 'BUFF',
+     "BUUU", "BUUB", "BUUF", "BUVU", "BUVB", "BUVF", "BUBU", "BUBB", "BUBF",
+     "BULU", "BULB", "BULF", "BUFU", "BUFB", "BUFF",
      #
-     'BVUU', 'BVUB', 'BVUF', 'BVVU', 'BVVB', 'BVVF', 'BVBU', 'BVBB', 'BVBF',
-     'BVLU', 'BVLB', 'BVLF', 'BVFU', 'BVFB', 'BVFF',
+     "BVUU", "BVUB", "BVUF", "BVVU", "BVVB", "BVVF", "BVBU", "BVBB", "BVBF",
+     "BVLU", "BVLB", "BVLF", "BVFU", "BVFB", "BVFF",
      #
-     'FUUU', 'FUUB', 'FUUF', 'FUVU', 'FUVB', 'FUVF', 'FUBU', 'FUBB', 'FUBF',
-     'FULU', 'FULB', 'FULF', 'FUFU', 'FUFB', 'FUFF',
+     "FUUU", "FUUB", "FUUF", "FUVU", "FUVB", "FUVF", "FUBU", "FUBB", "FUBF",
+     "FULU", "FULB", "FULF", "FUFU", "FUFB", "FUFF",
      #
-     'FVUU', 'FVUB', 'FVUF', 'FVVU', 'FVVB', 'FVVF', 'FVBU', 'FVBB', 'FVBF',
-     'FVLU', 'FVLB', 'FVLF', 'FVFU', 'FVFB', 'FVFF',
+     "FVUU", "FVUB", "FVUF", "FVVU", "FVVB", "FVVF", "FVBU", "FVBB", "FVBF",
+     "FVLU", "FVLB", "FVLF", "FVFU", "FVFB", "FVFF",
      #
-     # 'sUUU', 'sUUB', 'sUUF', 'sUVU', 'sUVB', 'sUVF', 'sUBU', 'sUBB', 'sUBF',
-     # 'sULU', 'sULB', 'sULF', 'sUFU', 'sUFB', 'sUFF',
+     # "sUUU", "sUUB", "sUUF", "sUVU", "sUVB", "sUVF", "sUBU", "sUBB", "sUBF",
+     # "sULU", "sULB", "sULF", "sUFU", "sUFB", "sUFF",
      #
-     # 'sVUU', 'sVUB', 'sVUF', 'sVVU', 'sVVB', 'sVVF', 'sVBU', 'sVBB', 'sVBF',
-     # 'sVLU', 'sVLB', 'sVLF', 'sVFU', 'sVFB', 'sVFF'
+     # "sVUU", "sVUB", "sVUF", "sVVU", "sVVB", "sVVF", "sVBU", "sVBB", "sVBF",
+     # "sVLU", "sVLB", "sVLF", "sVFU", "sVFB", "sVFF"
 ])])
 
 REVERSE_TERM_COMBINATIONS = dict(
     [(value, key) for key, value in TERM_COMBINATIONS.items()])
 
 TERM_INSTANTIATION_DICT = {
-    'U': URIRef,
-    'B': BNode,
-    'V': Variable,
-    'L': Literal
+    "U": URIRef,
+    "B": BNode,
+    "V": Variable,
+    "L": Literal
 }
 
 GRAPH_TERM_DICT = {
-    'F': (QuotedGraph, URIRef),
-    'U': (Graph, URIRef),
-    'B': (Graph, BNode)
+    "F": (QuotedGraph, URIRef),
+    "U": (Graph, URIRef),
+    "B": (Graph, BNode)
 }
 
 
@@ -95,7 +96,7 @@ def normalizeGraph(graph):
 
     """
     if isinstance(graph, QuotedGraph):
-        return graph.identifier, 'F'
+        return graph.identifier, "F"
     else:
         return graph.identifier, term2Letter(graph.identifier)
 
@@ -136,21 +137,21 @@ def term2Letter(term):
 
     """
     if isinstance(term, URIRef):
-        return 'U'
+        return "U"
     elif isinstance(term, BNode):
-        return 'B'
+        return "B"
     elif isinstance(term, Literal):
-        return 'L'
+        return "L"
     elif isinstance(term, QuotedGraph):
-        return 'F'
+        return "F"
     elif isinstance(term, Variable):
-        return 'V'
+        return "V"
     elif isinstance(term, Statement):
-        return 's'
+        return "s"
     elif isinstance(term, Graph):
         return term2Letter(term.identifier)
     elif term is None:
-        return 'L'
+        return "L"
     else:
         raise Exception(
             ("The given term (%s) is not an instance of any " +
@@ -192,7 +193,7 @@ def triplePattern2termCombinations(triple):
 def type2TermCombination(member, klass, context):
     """Map a type to a TermCombo."""
     try:
-        rt = TERM_COMBINATIONS['%sU%s%s' %
+        rt = TERM_COMBINATIONS["%sU%s%s" %
                                (term2Letter(member),
                                 term2Letter(klass),
                                 normalizeGraph(context)[-1])]
@@ -200,12 +201,12 @@ def type2TermCombination(member, klass, context):
     except:
         raise Exception("Unable to persist" +
                         "classification triple: %s %s %s %s" %
-                        (member, 'rdf:type', klass, context))
+                        (member, "rdf:type", klass, context))
 
 
 def statement2TermCombination(subject, predicate, obj, context):
     """Map a statement to a Term Combo."""
-    return TERM_COMBINATIONS['%s%s%s%s' %
+    return TERM_COMBINATIONS["%s%s%s%s" %
                              (term2Letter(subject), term2Letter(predicate),
                               term2Letter(obj), normalizeGraph(context)[-1])]
 
@@ -220,7 +221,7 @@ def escape_quotes(qstr):
     Ported from Ft.Lib.DbUtil
     """
     if qstr is None:
-        return ''
+        return ""
     tmp = qstr.replace("\\", "\\\\")
     tmp = tmp.replace("'", "\\'")
     return tmp

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -2,3 +2,4 @@ coverage
 pg8000
 psycopg2
 MySQL-python
+setuptools>=18.5.0

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -3,3 +3,4 @@ pg8000
 psycopg2
 http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip
 -e git+https://github.com/davispuh/MySQL-for-Python-3#egg=MySQL-python
+setuptools>=18.5.0

--- a/run_tests.py
+++ b/run_tests.py
@@ -45,7 +45,6 @@ NOSE_ARGS = [
         '--with-doctest',
         '--doctest-extension=.doctest',
         '--doctest-tests',
-#        '--with-EARL',
     ]
 
 COVERAGE_EXTRA_ARGS = [
@@ -53,40 +52,41 @@ COVERAGE_EXTRA_ARGS = [
         '--cover-inclusive',
     ]
 
-DEFAULT_ATTRS = [] # ['!known_issue', '!sparql']
+DEFAULT_ATTRS = []  # ['!known_issue', '!sparql']
 
 DEFAULT_DIRS = ['test', 'rdflib_sqlalchemy']
 
 
 if __name__ == '__main__':
-
     from sys import argv, exit, stderr
-    try: import nose
+    from six import print_
+    try:
+        import nose
     except ImportError:
-        print >>stderr, """\
-    Requires Nose. Try:
+        print_("""\
+            Requires Nose. Try:
 
-        $ sudo easy_install nose
+                $ sudo easy_install nose
 
-    Exiting. """; exit(1)
-
+            Exiting.
+        """, file=stderr)
+        exit(1)
 
     if '--with-coverage' in argv:
-        try: import coverage
+        try:
+            import coverage  # noqa
         except ImportError:
-            print >>stderr, "No coverage module found, skipping code coverage."
+            print_("No coverage module found, skipping code coverage.", file=stderr)
             argv.remove('--with-coverage')
         else:
             NOSE_ARGS += COVERAGE_EXTRA_ARGS
-
 
     if True not in [a.startswith('-a') or a.startswith('--attr=') for a in argv]:
         argv.append('--attr=' + ','.join(DEFAULT_ATTRS))
 
     if not [a for a in argv[1:] if not a.startswith('-')]:
-        argv += DEFAULT_DIRS # since nose doesn't look here by default..
-
+        argv += DEFAULT_DIRS  # since nose doesn't look here by default..
 
     finalArgs = argv + NOSE_ARGS
-    print "Running nose with:", " ".join(finalArgs[1:])
+    print("Running nose with:", " ".join(finalArgs[1:]))
     nose.run_exit(argv=finalArgs)

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,18 @@ def setup_python3():
 
     return tmp_src
 
-kwargs = {}
+kwargs = dict(
+    install_requires=[
+        "rdflib>=4.0",
+        "six>=1.10.0",
+        "SQLAlchemy",
+    ],
+    tests_require="coveralls",
+)
+
 if sys.version_info[0] >= 3:
     from setuptools import setup
     # kwargs['use_2to3'] = True  # is done in setup_python3 above already
-    kwargs['install_requires'] = ["rdflib>=4.0", "SQLAlchemy"]
-    kwargs['tests_require'] = ['coveralls']
     kwargs['requires'] = []
     kwargs['src_root'] = setup_python3()
     assert setup
@@ -49,8 +55,6 @@ else:
         from setuptools import setup
         assert setup
         kwargs['test_suite'] = "nose.collector"
-        kwargs['install_requires'] = ["rdflib>=4.0", "SQLAlchemy"]
-        kwargs['tests_require'] = ['coveralls']
 
     except ImportError:
         from distutils.core import setup

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,9 @@
 from rdflib import plugin
 from rdflib import store
 
-plugin.register('SQLAlchemy', store.Store,
-        'rdflib_sqlalchemy.SQLAlchemy', 'SQLAlchemy')
+plugin.register(
+    "SQLAlchemy",
+    store.Store,
+    "rdflib_sqlalchemy.store",
+    "SQLAlchemy",
+)

--- a/test/context_case.py
+++ b/test/context_case.py
@@ -1,35 +1,37 @@
 import unittest
+
 from rdflib import BNode
 from rdflib import ConjunctiveGraph
 from rdflib import Graph
 from rdflib import URIRef
-from rdflib.store import Store
 from rdflib import plugin
-from rdflib.py3compat import PY3
+from rdflib.store import Store
+from six import string_types
 
-# logging.getLogger('sqlalchemy.engine').setLevel(logging.WARN)
+
+# logging.getLogger("sqlalchemy.engine").setLevel(logging.WARN)
 
 
 class ContextTestCase(unittest.TestCase):
     storetest = True
     identifier = URIRef("rdflib_test")
 
-    michel = URIRef(u'michel')
-    tarek = URIRef(u'tarek')
-    bob = URIRef(u'bob')
-    likes = URIRef(u'likes')
-    hates = URIRef(u'hates')
-    pizza = URIRef(u'pizza')
-    cheese = URIRef(u'cheese')
-    c1 = URIRef(u'context-1')
-    c2 = URIRef(u'context-2')
+    michel = URIRef(u"michel")
+    tarek = URIRef(u"tarek")
+    bob = URIRef(u"bob")
+    likes = URIRef(u"likes")
+    hates = URIRef(u"hates")
+    pizza = URIRef(u"pizza")
+    cheese = URIRef(u"cheese")
+    c1 = URIRef(u"context-1")
+    c2 = URIRef(u"context-2")
 
-    def setUp(self, uri='sqlite://', storename=None):
+    def setUp(self, uri="sqlite://", storename=None):
         store = plugin.get(storename, Store)(identifier=self.identifier)
         self.graph = ConjunctiveGraph(store, identifier=self.identifier)
         self.graph.open(uri, create=True)
 
-    def tearDown(self, uri='sqlite://'):
+    def tearDown(self, uri="sqlite://"):
         self.graph.destroy(uri)
         try:
             self.graph.close()
@@ -179,7 +181,7 @@ class ContextTestCase(unittest.TestCase):
         self.addStuffInMultipleContexts()
 
         def cid(c):
-            if (PY3 and not isinstance(c,(str, bytes))) or not isinstance(c, basestring):
+            if not isinstance(c, string_types):
                 return c.identifier
             return c
         self.assert_(self.c1 in list(map(cid, self.graph.contexts())))
@@ -342,5 +344,5 @@ class ContextTestCase(unittest.TestCase):
         asserte(len(list(triples((Any, Any, Any)))), 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/graph_case.py
+++ b/test/graph_case.py
@@ -1,34 +1,33 @@
 # -*- coding: utf-8 -*-
-
 import unittest
+
 from rdflib import Graph
-from rdflib import RDF
 from rdflib import URIRef
 from rdflib import Literal
 from rdflib import plugin
-from rdflib.store import Store
-from rdflib.py3compat import PY3
 from rdflib.parser import StringInputSource
+from rdflib.py3compat import PY3
+from rdflib.store import Store
 
 
 class GraphTestCase(unittest.TestCase):
     storetest = True
     identifier = URIRef("rdflib_test")
 
-    michel = URIRef(u'michel')
-    tarek = URIRef(u'tarek')
-    bob = URIRef(u'bob')
-    likes = URIRef(u'likes')
-    hates = URIRef(u'hates')
-    pizza = URIRef(u'pizza')
-    cheese = URIRef(u'cheese')
+    michel = URIRef(u"michel")
+    tarek = URIRef(u"tarek")
+    bob = URIRef(u"bob")
+    likes = URIRef(u"likes")
+    hates = URIRef(u"hates")
+    pizza = URIRef(u"pizza")
+    cheese = URIRef(u"cheese")
 
-    def setUp(self, uri='sqlite://', storename=None):
+    def setUp(self, uri="sqlite://", storename=None):
         store = plugin.get(storename, Store)(identifier=self.identifier)
         self.graph = Graph(store, identifier=self.identifier)
         self.graph.open(uri, create=True)
 
-    def tearDown(self, uri='sqlite://'):
+    def tearDown(self, uri="sqlite://"):
         self.graph.destroy(uri)
         try:
             self.graph.close()
@@ -246,10 +245,10 @@ class GraphTestCase(unittest.TestCase):
 
     def testStoreLiterals(self):
         bob = self.bob
-        says = URIRef(u'says')
-        hello = Literal(u'hello', lang='en')
-        konichiwa = Literal(u'こんにちは', lang='ja')
-        something = Literal(u'something')
+        says = URIRef(u"says")
+        hello = Literal(u"hello", lang="en")
+        konichiwa = Literal(u"こんにちは", lang="ja")
+        something = Literal(u"something")
 
         self.graph.add((bob, says, hello))
         self.graph.add((bob, says, konichiwa))
@@ -258,11 +257,11 @@ class GraphTestCase(unittest.TestCase):
 
         objs = list(self.graph.objects(subject=bob, predicate=says))
         for o in objs:
-            if o.value == u'hello':
-                self.assertEquals(o.language, 'en')
-            elif o.value == u'こんにちは':
-                self.assertEquals(o.language, 'ja')
-            elif o.value == u'something':
+            if o.value == u"hello":
+                self.assertEquals(o.language, "en")
+            elif o.value == u"こんにちは":
+                self.assertEquals(o.language, "ja")
+            elif o.value == u"something":
                 self.assertEquals(o.language, None)
             else:
                 self.fail()
@@ -270,15 +269,15 @@ class GraphTestCase(unittest.TestCase):
 
     def testStoreLiteralsXml(self):
         bob = self.bob
-        says = URIRef(u'http://www.rdflib.net/terms/says')
+        says = URIRef(u"http://www.rdflib.net/terms/says")
         objects = [
-            Literal(u'I\'m the one', lang='en'),
-            Literal(u'こんにちは', lang='ja'),
-            Literal(u'les garçons à Noël reçoivent des œufs', lang='fr')]
+            Literal(u"I'm the one", lang="en"),
+            Literal(u"こんにちは", lang="ja"),
+            Literal(u"les garçons à Noël reçoivent des œufs", lang="fr")]
 
         testdoc = (PY3 and bytes(xmltestdocXml, "UTF-8")) or xmltestdocXml
 
-        self.graph.parse(StringInputSource(testdoc), formal='xml')
+        self.graph.parse(StringInputSource(testdoc), formal="xml")
 
         objs = list(self.graph)
         self.assertEquals(len(objs), 3)
@@ -289,13 +288,12 @@ class GraphTestCase(unittest.TestCase):
 
     def testStoreLiteralsXmlQuote(self):
         bob = self.bob
-        says = URIRef(u'http://www.rdflib.net/terms/says')
-        imtheone = Literal(u'I\'m the one', lang='en')
+        says = URIRef(u"http://www.rdflib.net/terms/says")
+        imtheone = Literal(u"I'm the one", lang="en")
 
-        testdoc = (PY3 and bytes(xmltestdocXmlQuote, "UTF-8")
-            ) or xmltestdocXmlQuote
+        testdoc = (PY3 and bytes(xmltestdocXmlQuote, "UTF-8")) or xmltestdocXmlQuote
 
-        self.graph.parse(StringInputSource(testdoc), formal='xml')
+        self.graph.parse(StringInputSource(testdoc), formal="xml")
 
         objs = list(self.graph)
         self.assertEquals(len(objs), 1)
@@ -348,8 +346,7 @@ n3testdoc = """@prefix : <http://example.org/> .
 :a :b :c .
 """
 
-nttestdoc = \
-"<http://example.org/a> <http://example.org/b> <http://example.org/c> .\n"
+nttestdoc = "<http://example.org/a> <http://example.org/b> <http://example.org/c> .\n"
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -1,19 +1,33 @@
-from rdflib import Graph, BNode, Literal, URIRef, RDFS, RDF, plugin, Namespace
-from rdflib.store import Store
 import os
+import shutil
+try:
+    from commands import getoutput
+except ImportError:
+    # Python 3
+    from subprocess import getoutput
+
+from rdflib import (
+    BNode,
+    Graph,
+    Literal,
+    RDF,
+    RDFS,
+    URIRef,
+    plugin,
+)
+from rdflib.store import Store
 
 
 # Work in progress
 
 
 def investigate_len_issue():
-    import shutil, commands
-    store = plugin.get('SQLAlchemy', Store)(
+    store = plugin.get("SQLAlchemy", Store)(
         identifier=URIRef("rdflib_test"),
         configuration=Literal("sqlite:///%(here)s/development.sqlite" % {
                                                         "here": os.getcwd()}))
-    g0 = Graph('Sleepycat')
-    g0.open('/tmp/foo', create=True)
+    g0 = Graph("Sleepycat")
+    g0.open("/tmp/foo", create=True)
     print("Len g0 on opening: %s\n" % len(g0))
     g1 = Graph(store)
     print("Len g1 on opening: %s\n" % len(g1))
@@ -22,11 +36,11 @@ def investigate_len_issue():
     g0.add((statementId, RDF.type, RDF.Statement))
     g1.add((statementId, RDF.type, RDF.Statement))
     print("Adding %s\n\t%s\n\t%s\n" % (statementId, RDF.subject,
-           URIRef(u'http://rdflib.net/store/ConjunctiveGraph')))
+          URIRef(u"http://rdflib.net/store/ConjunctiveGraph")))
     g0.add((statementId, RDF.subject,
-           URIRef(u'http://rdflib.net/store/ConjunctiveGraph')))
+           URIRef(u"http://rdflib.net/store/ConjunctiveGraph")))
     g1.add((statementId, RDF.subject,
-           URIRef(u'http://rdflib.net/store/ConjunctiveGraph')))
+           URIRef(u"http://rdflib.net/store/ConjunctiveGraph")))
     print("Adding %s\n\t%s\n\t%s\n" % (statementId, RDF.predicate, RDFS.label))
     g0.add((statementId, RDF.predicate, RDFS.label))
     g1.add((statementId, RDF.predicate, RDFS.label))
@@ -44,7 +58,7 @@ def investigate_len_issue():
     for s, p, o in g1:
         print("s = %s\n\tp = %s\n\to = %s\n" % (
             repr(s), repr(p), repr(o)))
-    commands.getoutput('cp development.sqlite devcopy.sqlite')
+    getoutput("cp development.sqlite devcopy.sqlite")
     print("Removing %s\n\t%s\n\t%s\n" % (statementId, RDF.type, RDF.Statement))
     g0.remove((statementId, RDF.type, RDF.Statement))
     print("Len g0 after removal %s\n" % len(g0))
@@ -53,9 +67,9 @@ def investigate_len_issue():
     print(g0.serialize(format="nt") + "\n")
     print(g1.serialize(format="nt") + "\n")
     g0.close()
-    shutil.rmtree('/tmp/foo')
+    shutil.rmtree("/tmp/foo")
     g1.close()
     os.unlink("%(here)s/development.sqlite" % {"here": os.getcwd()})
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     investigate_len_issue()

--- a/test/test_aggregate_graphs.py
+++ b/test/test_aggregate_graphs.py
@@ -1,21 +1,17 @@
 import unittest
+
 from nose.exc import SkipTest
 from rdflib import Literal
-from rdflib import plugin
-from rdflib import query
 from rdflib import RDF
 from rdflib import RDFS
 from rdflib import URIRef
-from rdflib.store import Store
-from rdflib.graph import Graph
+from rdflib import plugin
+from rdflib import query
 from rdflib.graph import ConjunctiveGraph
+from rdflib.graph import Graph
 from rdflib.graph import ReadOnlyGraphAggregate
-from rdflib.py3compat import PY3
-
-if PY3:
-    from io import StringIO
-else:
-    from cStringIO import StringIO
+from rdflib.store import Store
+from six.moves import cStringIO as StringIO
 
 
 plugin.register(
@@ -101,7 +97,7 @@ class GraphAggregates1(unittest.TestCase):
             [self.graph1, self.graph2, self.graph3])
 
     def testAggregateRaw(self):
-        #Test triples
+        # Test triples
         assert len(list(
             self.G.triples((None, RDF.type, None)))) == 4
         assert len(list(
@@ -109,15 +105,15 @@ class GraphAggregates1(unittest.TestCase):
         assert len(list(
             self.G.triples((None, URIRef("http://test/d"), None)))) == 3
 
-        #Test __len__
+        # Test __len__
         # assert len(self.G) == 8, self.G.serialize(format="nt")
         assert len(list(self.G.triples((None, None, None)))) == 8
 
-        #assert context iteration
+        # assert context iteration
         for g in self.G.contexts():
             assert isinstance(g, Graph)
 
-        #Test __contains__
+        # Test __contains__
         assert (URIRef("http://test/foo"), RDF.type, RDFS.Resource) in self.G
 
         barPredicates = [URIRef("http://test/d"), RDFS.isDefinedBy]
@@ -131,6 +127,7 @@ class GraphAggregates2(unittest.TestCase):
     def setUp(self):
         memStore = plugin.get('SQLAlchemy', Store)(
             identifier="rdflib_test", configuration=Literal("sqlite://"))
+        print("ASDF")
         self.graph1 = Graph(memStore, URIRef("http://example.com/graph1"))
         self.graph2 = Graph(memStore, URIRef("http://example.com/graph2"))
         self.graph3 = Graph(memStore, URIRef("http://example.com/graph3"))
@@ -139,9 +136,10 @@ class GraphAggregates2(unittest.TestCase):
                              (testGraph2N3, self.graph2),
                              (testGraph3N3, self.graph3)]:
             graph.parse(StringIO(n3Str), format='n3')
-
         self.graph4 = Graph(memStore, RDFS.uri)
+        print("ASDF B")
         self.graph4.parse(RDFS.uri)
+        print("ASDF C")
         self.G = ConjunctiveGraph(memStore)
 
     def testAggregateSPARQL(self):
@@ -175,11 +173,10 @@ class GraphAggregates3(unittest.TestCase):
         self.G = ConjunctiveGraph(memStore)
 
     def testDefaultGraph(self):
-        #test that CG includes triples from all 3
-        assert self.G.query(
-            sparqlQ3), "CG as default graph should *all* triples"
+        # test that CG includes triples from all 3
+        assert self.G.query(sparqlQ3), "CG as default graph should *all* triples"
         assert not self.graph2.query(sparqlQ3), "Graph as " + \
-                "default graph should *not* include triples from other graphs"
+            "default graph should *not* include triples from other graphs"
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_aggregate_graphs_base.py
+++ b/test/test_aggregate_graphs_base.py
@@ -60,7 +60,7 @@
 
 # sparqlQ3 =\
 # """
-# PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> 
+# PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 # PREFIX log: <http://www.w3.org/2000/10/swap/log#>
 # SELECT ?n3Doc
 # WHERE {?n3Doc a log:N3Document }"""
@@ -83,28 +83,29 @@
 #                              (testGraph3N3, self.graph3)]:
 #             graph.parse(StringIO(n3Str), format='n3')
 #             _logger.debug("Graph... %s" % graph.serialize(format="nt"))
-    
+
 #         self.G = ReadOnlyGraphAggregate([self.graph1, self.graph2, self.graph3])
 
 #     def testAggregateRaw(self):
 #         #Test triples
-#         assert len(list(self.G.triples((None, RDF.type, None))))                  == 4, len(list(self.G.triples((None, RDF.type, None)))) 
+#         assert len(list(self.G.triples((None, RDF.type, None)))) == 4,
+#              len(list(self.G.triples((None, RDF.type, None))))
 #         assert len(list(self.G.triples((URIRef("http://test/bar"), None, None)))) == 2
 #         assert len(list(self.G.triples((None, URIRef("http://test/d"), None))))   == 3
-    
+
 #         #Test __len__
 #         assert len(self.G) == 8, self.G.serialize(format="nt")
-        
+
 #         #assert context iteration
 #         for g in self.G.contexts():
 #             assert isinstance(g, Graph)
-    
+
 #         #Test __contains__
 #         assert (URIRef("http://test/foo"), RDF.type, RDFS.Resource) in self.G
-    
+
 #         barPredicates = [URIRef("http://test/d"), RDFS.isDefinedBy]
 #         assert len(list(self.G.triples_choices((URIRef("http://test/bar"), barPredicates, None)))) == 2
-    
+
 # class GraphAggregates2(unittest.TestCase):
 #     def setUp(self):
 #         memStore = plugin.get('SQLAlchemyBase', Store)(
@@ -112,12 +113,12 @@
 #         self.graph1 = Graph(memStore, URIRef("http://example.com/graph1"))
 #         self.graph2 = Graph(memStore, URIRef("http://example.com/graph2"))
 #         self.graph3 = Graph(memStore, URIRef("http://example.com/graph3"))
-    
+
 #         for n3Str,graph in [(testGraph1N3, self.graph1),
 #                             (testGraph2N3, self.graph2),
 #                             (testGraph3N3, self.graph3)]:
 #             graph.parse(StringIO(n3Str), format='n3')
-    
+
 #         self.graph4 = Graph(memStore, RDFS.uri)
 #         self.graph4.parse(RDFS.uri)
 #         self.G = ConjunctiveGraph(memStore)
@@ -140,17 +141,18 @@
 #         self.graph1 = Graph(memStore,URIRef("graph1"))
 #         self.graph2 = Graph(memStore,URIRef("graph2"))
 #         self.graph3 = Graph(memStore,URIRef("graph3"))
-        
+
 #         for n3Str, graph in [(testGraph1N3,self.graph1),
 #                             (testGraph2N3,self.graph2),
 #                             (testGraph3N3,self.graph3)]:
 #             graph.parse(StringIO(n3Str),format='n3')
 #         self.G = ConjunctiveGraph(memStore)
 
-#     def testDefaultGraph(self):    
+#     def testDefaultGraph(self):
 #         #test that CG includes triples from all 3
 #         assert self.G.query(sparqlQ3), "CG as default graph should *all* triples"
-#         assert not self.graph2.query(sparqlQ3), "Graph as default graph should *not* include triples from other graphs"
+#         assert not self.graph2.query(sparqlQ3),
+#             "Graph as default graph should *not* include triples from other graphs"
 
 # if __name__ == '__main__':
 #     unittest.main()

--- a/test/test_sqlalchemy.py
+++ b/test/test_sqlalchemy.py
@@ -1,28 +1,42 @@
-import unittest
 import logging
-from rdflib.store import Store
+import unittest
+
+from rdflib import (
+    BNode,
+    ConjunctiveGraph,
+    Literal,
+    URIRef,
+)
 from rdflib import plugin
-from rdflib import BNode, ConjunctiveGraph, Literal, URIRef
+from rdflib.store import Store
+
+from rdflib_sqlalchemy import registerplugins
+from rdflib_sqlalchemy.store import (
+    skolemise,
+    deskolemise,
+    _parse_rfc1738_args,
+)
+
 
 _logger = logging.getLogger(__name__)
 
-michel = URIRef(u'michel')
-tarek = URIRef(u'tarek')
-bob = URIRef(u'bob')
-likes = URIRef(u'likes')
-hates = URIRef(u'hates')
-pizza = URIRef(u'pizza')
-cheese = URIRef(u'cheese')
+michel = URIRef(u"michel")
+tarek = URIRef(u"tarek")
+bob = URIRef(u"bob")
+likes = URIRef(u"likes")
+hates = URIRef(u"hates")
+pizza = URIRef(u"pizza")
+cheese = URIRef(u"cheese")
 
 
 class mock_cursor():
     def execute(x):
-        raise Exception('Forced exception')
+        raise Exception("Forced exception")
 
 
 class SQLATestCase(unittest.TestCase):
     identifier = URIRef("rdflib_test")
-    dburi = Literal('sqlite://')
+    dburi = Literal("sqlite://")
 
     def setUp(self):
         self.store = plugin.get(
@@ -40,42 +54,35 @@ class SQLATestCase(unittest.TestCase):
     def test_registerplugins(self):
         # I doubt this is quite right for a fresh pip installation,
         # this test is mainly here to fill a coverage gap.
-        from rdflib_sqlalchemy import registerplugins
-        from rdflib import plugin
-        from rdflib.store import Store
         registerplugins()
-        self.assert_(plugin.get('SQLAlchemy', Store) is not None)
+        self.assert_(plugin.get("SQLAlchemy", Store) is not None)
         p = plugin._plugins
-        self.assert_(('SQLAlchemy', Store) in p, p)
-        del p[('SQLAlchemy', Store)]
+        self.assert_(("SQLAlchemy", Store) in p, p)
+        del p[("SQLAlchemy", Store)]
         plugin._plugins = p
         registerplugins()
-        self.assert_(('SQLAlchemy', Store) in p, p)
+        self.assert_(("SQLAlchemy", Store) in p, p)
 
     def test_skolemisation(self):
-        from rdflib_sqlalchemy.SQLAlchemy import skolemise
         testbnode = BNode()
         statemnt = (michel, likes, testbnode)
         res = skolemise(statemnt)
-        self.assert_('bnode:N' in str(res[2]), res)
+        self.assert_("bnode:N" in str(res[2]), res)
 
     def test_deskolemisation(self):
-        from rdflib_sqlalchemy.SQLAlchemy import deskolemise
         testbnode = BNode()
         statemnt = (michel, likes, testbnode)
         res = deskolemise(statemnt)
-        self.assert_(str(res[2]).startswith('N'), res)
+        self.assert_(str(res[2]).startswith("N"), res)
 
     def test_redeskolemisation(self):
-        from rdflib_sqlalchemy.SQLAlchemy import skolemise, deskolemise
         testbnode = BNode()
         statemnt = skolemise((michel, likes, testbnode))
         res = deskolemise(statemnt)
-        self.assert_(str(res[2]).startswith('N'), res)
+        self.assert_(str(res[2]).startswith("N"), res)
 
     def test__parse_rfc1738_args(self):
-        from rdflib_sqlalchemy.SQLAlchemy import _parse_rfc1738_args
-        self.assertRaises(ValueError, _parse_rfc1738_args, 'Not parseable')
+        self.assertRaises(ValueError, _parse_rfc1738_args, "Not parseable")
 
     def test_namespaces(self):
         self.assert_(list(self.graph.namespaces()) != [])
@@ -94,5 +101,5 @@ class SQLATestCase(unittest.TestCase):
         self.store._remove_context(self.identifier)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_sqlalchemy_mysql.py
+++ b/test/test_sqlalchemy_mysql.py
@@ -1,9 +1,14 @@
-import unittest
-from nose import SkipTest
-from rdflib.py3compat import PY3
+import logging
 import os
-if os.environ.get('DB') != 'mysql':
-    raise SkipTest("MySQL not under test")
+import unittest
+
+from nose import SkipTest
+from rdflib import Literal
+from rdflib.py3compat import PY3
+
+from . import context_case
+from . import graph_case
+
 if PY3:
     try:
         import mysql
@@ -18,15 +23,16 @@ else:
         dialect = "mysqldb"
     except ImportError:
         raise SkipTest("MySQLdb not found, skipping MySQL tests")
-import logging
+
+
+if os.environ.get("DB") != "mysql":
+    raise SkipTest("MySQL not under test")
+
 _logger = logging.getLogger(__name__)
-from . import context_case
-from . import graph_case
-from rdflib import Literal
 
 # Specific to Travis-ci continuous integration and testing ...
 sqlalchemy_url = Literal(os.environ.get(
-    'DBURI',
+    "DBURI",
     "mysql+%s://root@127.0.0.1:3306/test?charset=utf8" % dialect))
 # Generally ...
 # sqlalchemy_url = Literal(
@@ -40,7 +46,7 @@ class SQLAMySQLGraphTestCase(graph_case.GraphTestCase):
     create = True
 
     def setUp(self):
-        super(SQLAMySQLGraphTestCase,self).setUp(
+        super(SQLAMySQLGraphTestCase, self).setUp(
             uri=self.uri, storename=self.storename)
 
     def tearDown(self):
@@ -88,5 +94,5 @@ SQLAMySQLGraphTestCase.storetest = True
 SQLAMySQLContextTestCase.storetest = True
 SQLAMySQLIssueTestCase.storetest = True
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_sqlalchemy_postgresql.py
+++ b/test/test_sqlalchemy_postgresql.py
@@ -1,20 +1,25 @@
+import logging
 import os
 import unittest
-from nose.exc import SkipTest
-if os.environ.get('DB') != 'pgsql':
-    raise SkipTest("PgSQL not under test")
+
+from nose import SkipTest
 try:
-    import psycopg2
+    import psycopg2  # noqa
 except ImportError:
     raise SkipTest("psycopg2 not installed, skipping PgSQL tests")
-import logging
-_logger = logging.getLogger(__name__)
+
 from . import context_case
 from . import graph_case
 
+
+if os.environ.get("DB") != "pgsql":
+    raise SkipTest("PgSQL not under test")
+
 sqlalchemy_url = os.environ.get(
-    'DBURI',
-    'postgresql+psycopg2://postgres@localhost/test')
+    "DBURI",
+    "postgresql+psycopg2://postgres@localhost/test")
+
+_logger = logging.getLogger(__name__)
 
 
 class SQLAPgSQLGraphTestCase(graph_case.GraphTestCase):
@@ -50,5 +55,5 @@ class SQLAPgSQLContextTestCase(context_case.ContextTestCase):
 SQLAPgSQLGraphTestCase.storetest = True
 SQLAPgSQLContextTestCase.storetest = True
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_sqlalchemy_postgresql_pg8000.py
+++ b/test/test_sqlalchemy_postgresql_pg8000.py
@@ -1,22 +1,27 @@
 """pg8000 test."""
+import logging
 import os
 import unittest
-import logging
-from nose.exc import SkipTest
-from . import context_case
-from . import graph_case
-if os.environ.get('DB') != 'pgsql':
-    raise SkipTest("PgSQL not under test")
+
+from nose import SkipTest
 try:
     import pg8000
     assert pg8000 is not None
 except ImportError:
     raise SkipTest("pg8000 not installed, skipping PgSQL tests")
+
+from . import context_case
+from . import graph_case
+
+
+if os.environ.get("DB") != "pgsql":
+    raise SkipTest("PgSQL not under test")
+
 _logger = logging.getLogger(__name__)
 
 sqlalchemy_url = os.environ.get(
-    'DBURI',
-    'postgresql+pg8000://postgres@localhost/test')
+    "DBURI",
+    "postgresql+pg8000://postgres@localhost/test")
 
 
 class SQLAPgSQLGraphTestCase(graph_case.GraphTestCase):
@@ -61,5 +66,5 @@ class SQLAPgSQLContextTestCase(context_case.ContextTestCase):
 # SQLAPgSQLGraphTestCase.storetest = True
 # SQLAPgSQLContextTestCase.storetest = True
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_sqlalchemy_sqlite.py
+++ b/test/test_sqlalchemy_sqlite.py
@@ -1,15 +1,20 @@
-from nose.exc import SkipTest
-import os
-if os.environ.get('DB') != 'sqlite':
-    raise SkipTest("SQLite not under test")
-import unittest
 import logging
-_logger = logging.getLogger(__name__)
-from . import context_case
-from . import graph_case
+import os
+import unittest
+
+from nose import SkipTest
 from rdflib import Literal
 
-sqlalchemy_url = Literal(os.environ.get('DBURI',"sqlite://"))
+from . import context_case
+from . import graph_case
+
+
+if os.environ.get("DB") != "sqlite":
+    raise SkipTest("SQLite not under test")
+
+_logger = logging.getLogger(__name__)
+
+sqlalchemy_url = Literal(os.environ.get("DBURI", "sqlite://"))
 
 
 class SQLASQLiteGraphTestCase(graph_case.GraphTestCase):
@@ -44,5 +49,5 @@ SQLASQLiteGraphTestCase.storetest = True
 SQLASQLiteContextTestCase.storetest = True
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_store_performance.py
+++ b/test/test_store_performance.py
@@ -1,18 +1,17 @@
 """Store performance tests."""
-import unittest
 import gc
-import os
 import itertools
-from time import time
+import os
+import unittest
 from random import random
 from tempfile import mkdtemp
+from time import time
+
+from nose import SkipTest
 from rdflib import Graph
 from rdflib import URIRef
-try:
-    from urllib.request import pathname2url
-except:
-    from urllib import pathname2url
-from nose import SkipTest
+from six.moves.urllib.request import pathname2url
+
 
 raise SkipTest("Store performance test suspended")
 
@@ -27,10 +26,10 @@ class StoreTestCase(unittest.TestCase):
     Test case for testing store performance.
 
     Probably should be something other than a unit test
-    but for now we'll add it as a unit test.
+    but for now we"ll add it as a unit test.
     """
 
-    store = 'IOMemory'
+    store = "IOMemory"
     path = None
     storetest = True
     performancetest = True
@@ -54,13 +53,13 @@ class StoreTestCase(unittest.TestCase):
         # TODO: delete a_tmp_dir
         self.graph.close()
         del self.graph
-        if hasattr(self, 'path') and self.path is not None:
+        if hasattr(self, "path") and self.path is not None:
             if os.path.exists(self.path):
                 if os.path.isdir(self.path):
                     for f in os.listdir(self.path):
-                        os.unlink(self.path + '/' + f)
+                        os.unlink(self.path + "/" + f)
                     os.rmdir(self.path)
-                elif len(self.path.split(':')) == 1:
+                elif len(self.path.split(":")) == 1:
                     os.unlink(self.path)
                 else:
                     os.remove(self.path)
@@ -68,11 +67,11 @@ class StoreTestCase(unittest.TestCase):
     def testTime(self):
         """Test timing."""
         # number = 1
-        print('"%s": [' % self.store)
-        for i in ['500triples', '1ktriples', '2ktriples',
-                  '3ktriples', '5ktriples', '10ktriples',
-                  '25ktriples']:
-            inputloc = os.getcwd() + '/test/sp2b/%s.n3' % i
+        print("'%s': [" % self.store)
+        for i in ["500triples", "1ktriples", "2ktriples",
+                  "3ktriples", "5ktriples", "10ktriples",
+                  "25ktriples"]:
+            inputloc = os.getcwd() + "/test/sp2b/%s.n3" % i
             res = self._testInput(inputloc)
             print("%s," % res.strip())
         print("],")
@@ -105,5 +104,5 @@ class SQLAlchemyStoreTestCase(StoreTestCase):
             "here": os.getcwd()}
         StoreTestCase.setUp(self)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR contains various fixes to make the package more maintainable, specifically making it PEP8 (flake8) compliant, and fixes some Python 3 compatibility issues (e.g as noted in Issue #16). 

Main changes:
- Rename 'SQLAlchemy' file to 'store', fixing the issue raised in #16 for Python 3
- Use the standard Python 2/3 compatibility library [six](https://pythonhosted.org/six/) to replace conditional logic in multiple places in code (added six as dependency)
- Remove deprecated pip '--use-mirrors' flag from Travis CI config file (this was removed from pip in 7.0.0: https://pip.pypa.io/en/stable/news/#release-notes)
- added 'setuptools' explicitly to requirements-py{2,3}.txt files as Travis CI builds were failing due to an out of date version
- Make code [flake8](http://flake8.pycqa.org/en/latest/index.html) compliant, re-shuffle some imports to adhere to PEP8 conventions and alphabetize them, also moving some imports that were nested in functions to top of files
- Rename all files to be lowercase, being more uniform and avoiding issues with some OSes having trouble with case-sensitive filenames
- Standardized on using double quotes everywhere in code - had a mix of single and double previously
- Some cleanup in setup.py to try and make it less redundant / more readable - I think a big refactoring of this file is imminent..

Verified all unit-tests passed on TravisCI after changes