### PR TITLE
Call engine.dispose() before setting to None in close()

### DIFF
--- a/rdflib_sqlalchemy/store.py
+++ b/rdflib_sqlalchemy/store.py
@@ -253,7 +253,8 @@ class SQLAlchemy(Store, SQLGeneratorMixin, StatisticsMixin):
         Close the current store engine connection if one is open.
 
         """
-        self.engine.dispose()
+        if self.engine:
+            self.engine.dispose()
         self.engine = None
 
     def destroy(self, configuration):

--- a/rdflib_sqlalchemy/store.py
+++ b/rdflib_sqlalchemy/store.py
@@ -253,6 +253,7 @@ class SQLAlchemy(Store, SQLGeneratorMixin, StatisticsMixin):
         Close the current store engine connection if one is open.
 
         """
+        self.engine.dispose()
         self.engine = None
 
     def destroy(self, configuration):


### PR DESCRIPTION
Hoping this fixes #26 - MySQL connection leak.

See http://docs.sqlalchemy.org/en/latest/core/connections.html#engine-disposal for reference