### PR TITLE
Using groups of choices in triples_choices (#43)

### DIFF
--- a/rdflib_sqlalchemy/store.py
+++ b/rdflib_sqlalchemy/store.py
@@ -168,13 +168,14 @@ class SQLAlchemy(Store, SQLGeneratorMixin, StatisticsMixin):
                 typeLen, quotedLen, assertedLen, literalLen = [
                     rtTuple[0] for rtTuple in rt]
             try:
-                return ("<Partitioned SQL N3 Store: %s " +
-                        "contexts, %s classification assertions, " +
-                        "%s quoted statements, %s property/value " +
+                return ("<Partitioned SQL N3 Store: %s "
+                        "contexts, %s classification assertions, "
+                        "%s quoted statements, %s property/value "
                         "assertions, and %s other assertions>" % (
-                            len([ctx for ctx in self.contexts()]),
+                            sum(1 for _ in self.contexts()),
                             typeLen, quotedLen, literalLen, assertedLen))
             except Exception:
+                _logger.exception('Error creating repr')
                 return "<Partitioned SQL N3 Store>"
         else:
             return "<Partitioned unopened SQL N3 Store>"

--- a/test/graph_case.py
+++ b/test/graph_case.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from rdflib import Graph
-from rdflib import URIRef
-from rdflib import Literal
-from rdflib import plugin
+from rdflib import Graph, URIRef, Literal, plugin
 from rdflib.parser import StringInputSource
 from rdflib.py3compat import PY3
 from rdflib.store import Store
@@ -316,6 +313,25 @@ class GraphTestCase(unittest.TestCase):
         self.assertEqual(
             self.graph.qname(self.namespace_saws + u"title"), "ns1:title",
             "Unknown prefixes for namespace should be transformed to nsX"
+        )
+
+    def testTriplesChoices(self):
+        likes = self.likes
+        pizza = self.pizza
+        cheese = self.cheese
+        tarek = self.tarek
+        michel = self.michel
+        bob = self.bob
+        self.addStuff()
+        trips = self.graph.triples_choices((None, likes, [pizza, cheese]))
+        self.assertEqual(
+            set(trips),
+            set([(tarek, likes, pizza),
+                 (tarek, likes, pizza),
+                 (tarek, likes, cheese),
+                 (michel, likes, pizza),
+                 (michel, likes, cheese),
+                 (bob, likes, cheese)])
         )
 
 

--- a/test/test_sqlalchemy.py
+++ b/test/test_sqlalchemy.py
@@ -1,9 +1,9 @@
 import unittest
 
 try:
-    from unittest.mock import patch
+    from unittest.mock import patch, MagicMock
 except ImportError:
-    from mock import patch
+    from mock import patch, MagicMock
 
 import six
 
@@ -16,6 +16,7 @@ from rdflib import (
 from rdflib.store import Store
 
 from rdflib_sqlalchemy import registerplugins
+from sqlalchemy.sql.selectable import Select
 
 
 michel = URIRef(u"michel")
@@ -57,7 +58,7 @@ class SQLATestCase(unittest.TestCase):
 
     def setUp(self):
         self.store = plugin.get(
-            "SQLAlchemy", Store)(identifier=self.identifier)
+            "SQLAlchemy", Store)(identifier=self.identifier, configuration=self.dburi)
         self.graph = ConjunctiveGraph(self.store, identifier=self.identifier)
         self.graph.open(self.dburi, create=True)
 
@@ -83,6 +84,13 @@ class SQLATestCase(unittest.TestCase):
     def test_contexts_without_triple(self):
         self.assertEqual(list(self.graph.contexts()), [])
 
+    def test_contexts_result(self):
+        ctx_id = URIRef('http://example.org/context')
+        g = self.graph.get_context(ctx_id)
+        g.add((michel, likes, pizza))
+        actual = list(self.store.contexts())
+        self.assertEqual(actual[0], ctx_id)
+
     def test_contexts_with_triple(self):
         statemnt = (michel, likes, pizza)
         self.assertEqual(list(self.graph.contexts(triple=statemnt)), [])
@@ -91,7 +99,29 @@ class SQLATestCase(unittest.TestCase):
         self.assertEqual(self.store.__len__(), 0)
 
     def test__remove_context(self):
-        self.store._remove_context(self.identifier)
+        ctx_id = URIRef('http://example.org/context')
+        g = self.graph.get_context(ctx_id)
+        g.add((michel, likes, pizza))
+        self.store._remove_context(g)
+        self.assertEqual(list(self.store.contexts()), [])
+
+    def test_triples_choices(self):
+        # Create a mock for the sqlalchemy engine so we can capture the arguments
+        p = MagicMock(name='engine')
+        self.store.engine = p
+
+        # Set this so we're not including selects for both asserted and literal tables for
+        # a choice
+        self.store.STRONGLY_TYPED_TERMS = True
+        # Set the grouping of terms
+        self.store.max_terms_per_where = 2
+        # force execution of the generator
+        for x in self.store.triples_choices((None, likes, [michel, pizza, likes])):
+            pass
+        args = p.connect().__enter__().execute.call_args[0]
+        children = args[0].get_children(column_collections=False)
+        # Expect two selects: one for the first two choices plus one for the last one
+        self.assertEqual(sum(1 for c in children if isinstance(c, Select)), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- SQLite only allows a certain number of terms in a WHERE clause. This
  change allows for calls to addN to always come under that limit.