### PR TITLE
Adding coveralls configs and removing deploy config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 
 env:
-- DB=pgsql
-- DB=mysql
-- DB=sqlite
+ global:
+ - COVERALLS_PARALLEL=true
+ matrix:
+ - DB=pgsql
+ - DB=mysql
+ - DB=sqlite
 
 services:
 - postgresql
@@ -17,21 +20,16 @@ python:
 - 3.7
 
 install:
-- pip install -U setuptools tox tox-travis
+- pip install -U setuptools tox tox-travis coveralls
 
 before_script:
 - ./travis-ci.sh
 
 script: tox
 
-deploy:
-  distributions: sdist bdist_wheel
-  provider: pypi
-  user: adamhadani
-  password:
-    secure: jSAo1pMtzpNSBJHOtn15WiT2XBL6JBTB/1u22CeRhW6tmRh4ngaK1+WAfuoRpgP5seTBnb1DIxiNzvCL5sRjq9ckbHgc7pW9EcpKCeDFjU1MQPH2GqQ37jicc4NY4TXu9pAUIbxIVwGxHWNCY0QPxIgCSVvTTKoiZn3QddL8hzg=
-  on:
-    tags: true
-    repo: RDFLib/rdflib-sqlalchemy
-    branch: develop
-    condition: $TRAVIS_PYTHON_VERSION = "3.5"
+notifications:
+  webhooks: https://coveralls.io/webhook
+
+after_script:
+- coveralls
+

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: BSD License",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,15 @@
 [tox]
 envlist =
-    py27,py34,py35,cover,lint
+    py27,py34,py35,py36,py37,lint
 
 [testenv]
 passenv = DB DBURI
 commands =
     {envpython} setup.py clean --all
-    {envpython} setup.py nosetests
+    {envpython} setup.py nosetests \
+                --with-coverage --cover-package=rdflib_sqlalchemy \
+                --cover-inclusive --cover-branches
+
 deps =
     psycopg2
     mysqlclient
@@ -19,7 +22,7 @@ deps =
     flake8-print
 
 [testenv:cover]
-basepython = python2.7
+basepython = python3.7
 commands =
     {envpython} setup.py nosetests \
                  --with-coverage --cover-html --cover-html-dir=./coverage \
@@ -30,8 +33,8 @@ deps =
 
 [travis]
 python =
-    2.7: py27, cover, lint
-    3.5: py35, lint
+    2.7: py27, lint
+    3.7: py37, lint
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
- Deployments will be done manually to PyPI so they can be built and
checked on more trusted hardware
- Removing coverage run for just python 3.5
- Moving lint run to python 3.7 from python 3.5