### PR TITLE
Support tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 passenv = DB,DBURI
 commands =
     {envpython} setup.py clean --all
-    pytest --cov=rdflib_sqlalchemy
+    {envpython} -m pytest --cov=rdflib_sqlalchemy
 
 deps =
     pytest>=3.4.0


### PR DESCRIPTION
External commands need to be listed in allowlist_externals. We can trivially drive pytest without executing an external command.