### PR TITLE
Fix `SQLAlchemy.destroy`: `open()` does not return an SQLAlchemy engine object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ rdflib_sqlalchemy.egg-info
 /.eggs/
 /dist/
 /venv/
+.venv*
 docs/api
+*.sqlite
 
 # JetBrains IDE files
 /.idea/
-

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,7 @@
 norecursedirs = .git env
 
 # Output in color, run doctests
-addopts = --color=yes
+addopts = -rfEXs --color=yes
 
 testpaths = test
 # Run tests from files matching this glob

--- a/rdflib_sqlalchemy/store.py
+++ b/rdflib_sqlalchemy/store.py
@@ -307,7 +307,7 @@ class SQLAlchemy(Store, SQLGeneratorMixin, StatisticsMixin):
         Delete all tables and stored data associated with the store.
         """
         if self.engine is None:
-            self.engine = self.open(configuration, create=False)
+            self.open(configuration, create=False)
 
         with self.engine.begin():
             try:


### PR DESCRIPTION
Dear Mark,

thanks a stack for conceiving this excellent package.

While working on GH-106, we discovered a minor flaw in the `SQLAlchemy.destroy` method. This patch fixes it. Along the lines, it slightly adjusts the `.gitignore` file, and the pytest configuration options.

With kind regards,
Andreas.
