### PR TITLE
Chore: Update to `rdflib>=6`, lower versions are failing the software tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,11 @@ rdflib_sqlalchemy.egg-info
 /.eggs/
 /dist/
 /venv/
+.venv*
 docs/api
 
 # JetBrains IDE files
 /.idea/
 
+# Test outcomes
+test/tmpdb.sqlite

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     ],
     install_requires=[
         "alembic>=0.8.8",
-        "rdflib>=4.0",
+        "rdflib>=6,<8",
         "six>=1.10.0",
         "SQLAlchemy>=1.1.4,<2.0.0",
     ],


### PR DESCRIPTION
## About

While aiming to have a look at what might be missing at GH-104, but still on `develop`, I discovered that a single software test case failed.

```
FAILED test/test_aggregate_graphs.py::GraphAggregates3::testDefaultGraph - AttributeError: property 'name' of 'Param' object has no setter
```

After updating to `rdflib>=6`, all software tests executed successfully. It works with both rdflib-6.x and rdflib-7.x so far.
