### PR TITLE
CI: Add alternative test configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Please see the documentation for all Dependabot configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,86 @@
+name: "Tests: PR"
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - ci-gha
+  pull_request: ~
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "
+    Python: ${{ matrix.python-version }}
+    SQLAlchemy: ${{ matrix.sqla-version }}
+    "
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        sqla-version: ['1.*']
+        pip-allow-prerelease: ['false']
+
+    env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      SQLALCHEMY_VERSION: ${{ matrix.sqla-version }}
+      PIP_ALLOW_PRERELEASE: ${{ matrix.pip-allow-prerelease }}
+
+    steps:
+
+      - name: Acquire sources
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+          cache: 'pip'
+          cache-dependency-path: |
+            setup.cfg
+            setup.py
+            test-requirements.txt
+
+      - name: Set up project
+        run: |
+
+          # `setuptools 0.64.0` adds support for editable install hooks (PEP 660).
+          # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
+          pip install "setuptools>=64" --upgrade
+
+          # Install package in editable mode.
+          pip install --use-pep517 --prefer-binary --editable='.[develop,test]'
+          
+          # Install development/test dependencies.
+          pip install -r test-requirements.txt
+          
+          # Explicitly install designated SQLAlchemy version to validate this test matrix slot.
+          pip install "sqlalchemy==${{ matrix.sqla-version }}"
+
+      - name: Invoke tests
+        run: |
+
+          # Report about the test matrix slot.
+          echo "Invoking tests with Python ${PYTHON_VERSION} and SQLAlchemy ${SQLALCHEMY_VERSION}"
+
+          # Run linters and software tests.
+          flake8 rdflib_sqlalchemy test
+          pytest
+
+      # https://github.com/codecov/codecov-action
+      - name: Upload coverage results to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
+          flags: main
+          env_vars: OS,PYTHON
+          name: codecov-umbrella
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,11 @@ rdflib_sqlalchemy.egg-info
 /.eggs/
 /dist/
 /venv/
+.venv*
+.coverage
+coverage.xml
 docs/api
 
 # JetBrains IDE files
 /.idea/
-
+test/tmpdb.sqlite

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 RDFLib-SQLAlchemy
 =================
 
+[![Tests](https://github.com/RDFLib/rdflib-sqlalchemy/actions/workflows/tests.yml/badge.svg)](https://github.com/RDFLib/rdflib-sqlalchemy/actions/workflows/tests.yml)
+
 A SQLAlchemy-backed, formula-aware RDFLib Store. It stores its triples
 in the following partitions:
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,10 @@
 norecursedirs = .git env
 
 # Output in color, run doctests
-addopts = --color=yes
+addopts =
+  -rsfEX -p pytester --strict-markers --verbosity=3
+  --cov=rdflib_sqlalchemy --cov-report=term-missing --cov-report=xml
+  --color=yes
 
 testpaths = test
 # Run tests from files matching this glob

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
 flake8
 mock==3.0.5 ; python_version=="2.7"
+pytest<8
+pytest-cov<5
 tox


### PR DESCRIPTION
## About

This patch configures GHA a bit differently to invoke the software tests, more in a vanilla configuration style.

## Status

![image](https://github.com/RDFLib/rdflib-sqlalchemy/assets/453543/348eecc5-1be6-4f53-b2fb-2bbb0bc6e33a)
-- https://github.com/crate-workbench/rdflib-sqlalchemy/actions/runs/7681302055

## Backlog

- [ ] Also run integration tests
- [ ] Remove tox configuration, unless there are objections about it
- [ ] Trim previous GHA configuration `python-package.yml`
