### PR TITLE
chore: pkg_resources is deprecated

### DIFF
--- a/rdflib_sqlalchemy/__init__.py
+++ b/rdflib_sqlalchemy/__init__.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 """SQLAlchemy Store plugin for RDFLib."""
 import logging
-from pkg_resources import get_distribution
+from importlib_metadata import version
 
-
-__version__ = get_distribution("rdflib_sqlalchemy").version
+__version__ = version("rdflib_sqlalchemy")
 
 
 class NullHandler(logging.Handler):

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "rdflib>=6,<8",
         "six>=1.10.0",
         "SQLAlchemy>=2.0.23",
+        "importlib-metadata~=8.4.0; python_version<'3.8'",
     ],
     entry_points={
         'rdf.plugins.store': [


### PR DESCRIPTION
`pkg_resources` is deprecated, so uses `importlib_metadata` instead.