### PR TITLE
Align `setUp` and `tearDown` type signatures with `unittest` and `rdflib.plugin`

### DIFF
--- a/test/graph_case.py
+++ b/test/graph_case.py
@@ -11,6 +11,10 @@ class GraphTestCase(unittest.TestCase):
     storetest = True
     identifier = URIRef("rdflib_test")
 
+    # storename is expected to be assigned in subclasses.
+    storename: str
+    uri: str = "sqlite://"
+
     michel = URIRef(u"michel")
     tarek = URIRef(u"tarek")
     bob = URIRef(u"bob")
@@ -23,13 +27,13 @@ class GraphTestCase(unittest.TestCase):
     namespace_dct = "http://purl.org/dc/terms/"
     namespace_saws = "http://purl.org/saws/ontology#"
 
-    def setUp(self, uri="sqlite://", storename=None):
-        store = plugin.get(storename, Store)(identifier=self.identifier)
+    def setUp(self) -> None:
+        store = plugin.get(self.storename, Store)(identifier=self.identifier)
         self.graph = Graph(store, identifier=self.identifier)
-        self.graph.open(uri, create=True)
+        self.graph.open(self.uri, create=True)
 
-    def tearDown(self, uri="sqlite://"):
-        self.graph.destroy(uri)
+    def tearDown(self) -> None:
+        self.graph.destroy(self.uri)
         self.graph.close()
 
     def addStuff(self):

--- a/test/test_sqlalchemy_mysql.py
+++ b/test/test_sqlalchemy_mysql.py
@@ -39,25 +39,12 @@ class SQLAMySQLGraphTestCase(graph_case.GraphTestCase):
     uri = sqlalchemy_url
     create = True
 
-    def setUp(self):
-        super(SQLAMySQLGraphTestCase, self).setUp(uri=self.uri, storename=self.storename)
-
-    def tearDown(self):
-        super(SQLAMySQLGraphTestCase, self).tearDown(uri=self.uri)
-
 
 class SQLAMySQLContextTestCase(context_case.ContextTestCase):
     storetest = True
     storename = "SQLAlchemy"
     uri = sqlalchemy_url
     create = True
-
-    def setUp(self):
-        super(SQLAMySQLContextTestCase, self).setUp(
-            uri=self.uri, storename=self.storename)
-
-    def tearDown(self):
-        super(SQLAMySQLContextTestCase, self).tearDown(uri=self.uri)
 
     def testLenInMultipleContexts(self):
         pytest.skip("Known issue.")

--- a/test/test_sqlalchemy_postgresql.py
+++ b/test/test_sqlalchemy_postgresql.py
@@ -30,30 +30,12 @@ class SQLAPgSQLGraphTestCase(graph_case.GraphTestCase):
     uri = sqlalchemy_url
     create = True
 
-    def setUp(self):
-        super(SQLAPgSQLGraphTestCase, self).setUp(
-            uri=self.uri,
-            storename=self.storename,
-        )
-
-    def tearDown(self):
-        super(SQLAPgSQLGraphTestCase, self).tearDown(uri=self.uri)
-
 
 class SQLAPgSQLContextTestCase(context_case.ContextTestCase):
     storetest = True
     storename = "SQLAlchemy"
     uri = sqlalchemy_url
     create = True
-
-    def setUp(self):
-        super(SQLAPgSQLContextTestCase, self).setUp(
-            uri=self.uri,
-            storename=self.storename,
-        )
-
-    def tearDown(self):
-        super(SQLAPgSQLContextTestCase, self).tearDown(uri=self.uri)
 
     def testLenInMultipleContexts(self):
         pytest.skip("Known issue.")

--- a/test/test_sqlalchemy_postgresql_pg8000.py
+++ b/test/test_sqlalchemy_postgresql_pg8000.py
@@ -5,7 +5,7 @@ import unittest
 
 import pytest
 try:
-    import pg8000
+    import pg8000  # type: ignore
     assert pg8000 is not None
 except ImportError:
     pytest.skip("pg8000 not installed, skipping PgSQL tests",
@@ -33,15 +33,6 @@ class SQLAPgSQLGraphTestCase(graph_case.GraphTestCase):
     uri = sqlalchemy_url
     create = True
 
-    def setUp(self):
-        """Setup."""
-        super(SQLAPgSQLGraphTestCase, self).setUp(
-            uri=self.uri, storename=self.storename)
-
-    def tearDown(self):
-        """Teardown."""
-        super(SQLAPgSQLGraphTestCase, self).tearDown(uri=self.uri)
-
 
 class SQLAPgSQLContextTestCase(context_case.ContextTestCase):
     """Context test case."""
@@ -50,15 +41,6 @@ class SQLAPgSQLContextTestCase(context_case.ContextTestCase):
     storename = "SQLAlchemy"
     uri = sqlalchemy_url
     create = True
-
-    def setUp(self):
-        """Setup."""
-        super(SQLAPgSQLContextTestCase, self).setUp(
-            uri=self.uri, storename=self.storename)
-
-    def tearDown(self):
-        """Teardown."""
-        super(SQLAPgSQLContextTestCase, self).tearDown(uri=self.uri)
 
     def testLenInMultipleContexts(self):
         """Test lin in multiple contexts, known issue."""

--- a/test/test_sqlalchemy_sqlite.py
+++ b/test/test_sqlalchemy_sqlite.py
@@ -22,25 +22,11 @@ class SQLASQLiteGraphTestCase(graph_case.GraphTestCase):
     storename = "SQLAlchemy"
     uri = sqlalchemy_url
 
-    def setUp(self):
-        super(SQLASQLiteGraphTestCase, self).setUp(
-            uri=self.uri, storename=self.storename)
-
-    def tearDown(self):
-        super(SQLASQLiteGraphTestCase, self).tearDown(uri=self.uri)
-
 
 class SQLASQLiteContextTestCase(context_case.ContextTestCase):
     storetest = True
     storename = "SQLAlchemy"
     uri = sqlalchemy_url
-
-    def setUp(self):
-        super(SQLASQLiteContextTestCase, self).setUp(
-            uri=self.uri, storename=self.storename)
-
-    def tearDown(self):
-        super(SQLASQLiteContextTestCase, self).tearDown(uri=self.uri)
 
     def testLenInMultipleContexts(self):
         pytest.skip("Known issue.")


### PR DESCRIPTION
The references below indicate the type requirements' sources.

When reviewing subclasses of `GraphTestCase`, `setUp` and `tearDown` did no further work than the parent class `GraphTestCase` once the signatures were aligned with `typeshed.stdlib`, so the methods were removed.

The first patch was driven by the following command after activating type review on `setUp` and `tearDown` (adding `-> None`):

```bash
mypy test/test_sqlalchemy_sqlite.py
```

The first patch was then tested with the following command after identifying sibling ("cousin?") classes of the SQLite test.  This command raised no errors after deactivating type review (adding `# type: ignore`) on a package that does not currently provide type signatures:

```bash
mypy \
  test/test_sqlalchemy_mysql.py \
  test/test_sqlalchemy_postgresql.py \
  test/test_sqlalchemy_postgresql_pg8000.py \
  test/test_sqlalchemy_sqlite.py
```

Note: The first patch was not tested by re-running the test suite.  However, I do think it will help with future review.


## Disclaimer:

Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.


## References

* https://github.com/RDFLib/rdflib/blob/7.1.1/rdflib/plugin.py#L128
* https://github.com/python/typeshed/blob/b40eb642e00c538e29fb037992eb4b21d9ff108c/stdlib/unittest/case.pyi#L119-L120