### PR TITLE
Fix for deprecated/removed `pkg_resources` package

### DIFF
--- a/rdflib_sqlalchemy/__init__.py
+++ b/rdflib_sqlalchemy/__init__.py
@@ -4,14 +4,11 @@ import logging
 import sys
 
 if sys.version_info >= (3, 8):
-    import importlib.metadata
-
-    __version__ = importlib.metadata.version("rdflib_sqlalchemy")
+    import importlib.metadata as importlib_metadata
 else:
-    # Implicit dependency on `setuptools<81` for Python < 3.8.
-    import pkg_resources
+    import importlib_metadata
 
-    __version__ = pkg_resources.get_distribution("rdflib_sqlalchemy").version
+__version__ = importlib_metadata.version("rdflib_sqlalchemy")
 
 
 class NullHandler(logging.Handler):

--- a/rdflib_sqlalchemy/__init__.py
+++ b/rdflib_sqlalchemy/__init__.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
 """SQLAlchemy Store plugin for RDFLib."""
 import logging
-from pkg_resources import get_distribution
+import sys
 
+if sys.version_info >= (3, 8):
+    import importlib.metadata
 
-__version__ = get_distribution("rdflib_sqlalchemy").version
+    __version__ = importlib.metadata.version("rdflib_sqlalchemy")
+else:
+    # Implicit dependency on `setuptools<81` for Python < 3.8.
+    import pkg_resources
+
+    __version__ = pkg_resources.get_distribution("rdflib_sqlalchemy").version
 
 
 class NullHandler(logging.Handler):

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "rdflib>=6,<8",
         "six>=1.10.0",
         "SQLAlchemy>=2.0.23",
+        "importlib-metadata; python_version < '3.8'",
     ],
     entry_points={
         'rdf.plugins.store': [


### PR DESCRIPTION
Resolves #115.

Used official Python backport to make `importlib.metadata` available prior to 3.8 ((https://github.com/python/importlib_metadata) and drop `pkg_resources` as a dependency completely.

https://github.com/RDFLib/rdflib-sqlalchemy/blob/00822e50da16a51924949e7164a77fa51dc27a90/setup.py#L35-L39

But maybe it's also good time to drop Python 3.7 support, since it's EOL for almost 3 years now (https://devguide.python.org/versions/).

@mwatts15 @richardscholtens can you please take a look?